### PR TITLE
add defaults instead of removing them so diff works like it should

### DIFF
--- a/dogpush/dogpush.py
+++ b/dogpush/dogpush.py
@@ -110,8 +110,8 @@ def _canonical_monitor(original, default_team=None, **kwargs):
         if m.get('options', {}).get(field) == value:
             del m['options'][field]
     for (field, value) in CONFIG['default_rules'].items():
-        if m.get(field) == value:
-            del m[field]
+        if field not in m:
+            m[field] = value
     # If options is {'thresholds': {'critical': x}}, then it is redundant.
     if not m.get('options'):
         m.pop('options', None)


### PR DESCRIPTION
adding default if it's not set, this way we send multi: false and type even though datadog has defaults.

running this against DD it does not add a bunch of new ones or update any.